### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/subashneupane20/5a9b9185-0649-4c2a-8bd3-c8b8019ffba0/7d9d4c28-8a9a-481f-bc65-1c8684557330/_apis/work/boardbadge/70a8a502-cefd-48cd-a3c3-6bebb3c02891)](https://dev.azure.com/subashneupane20/5a9b9185-0649-4c2a-8bd3-c8b8019ffba0/_boards/board/t/7d9d4c28-8a9a-481f-bc65-1c8684557330/Microsoft.RequirementCategory)
 # learning_git


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/subashneupane20/5a9b9185-0649-4c2a-8bd3-c8b8019ffba0/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.